### PR TITLE
Power On/Off Device (& Device Profile Class for Battery, Power, etc. information)

### DIFF
--- a/deviceprofile.cpp
+++ b/deviceprofile.cpp
@@ -1,0 +1,22 @@
+#include "deviceprofile.h"
+
+deviceProfile::deviceProfile(int deviceId, double batteryLevel)
+{
+    this->deviceId = deviceId;
+    this->batteryLevel = batteryLevel;
+}
+
+int deviceProfile::getDeviceId()
+{
+    return deviceId;
+}
+
+double deviceProfile::getBatteryLevel()
+{
+    return batteryLevel;
+}
+
+void deviceProfile::setBatteryLevel(double newBatteryLevel)
+{
+    batteryLevel = newBatteryLevel;
+}

--- a/deviceprofile.h
+++ b/deviceprofile.h
@@ -1,0 +1,18 @@
+#ifndef DEVICEPROFILE_H
+#define DEVICEPROFILE_H
+
+
+class deviceProfile
+{
+public:
+    deviceProfile(int, double);
+    int getDeviceId();
+    void setBatteryLevel(double);
+    double getBatteryLevel();
+
+private:
+    int deviceId;
+    double batteryLevel;
+};
+
+#endif // DEVICEPROFILE_H

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -3,12 +3,17 @@
 //#include "datetimedialog.h"
 #include <QDebug>
 #include <QLabel>
+#include "deviceprofile.h"
 
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
     , ui(new Ui::MainWindow)
 {
     ui->setupUi(this);
+    devProfile = new deviceProfile(1,100.00);
+    powerLevel = devProfile->getBatteryLevel();
+    isPowerOn = false;
+    togglePower();
 // THESE COMMENTS ARE FOR REFIXING THE SLOTS AFTER SWITCHING TO STACKED WIDGETS - SOFIA
 //    connect(ui->pauseBtn, SIGNAL(released()), this, SLOT(pauseSession()));
 //    connect(ui->startBtn, SIGNAL(released()), this, SLOT(resumeSession()));
@@ -19,7 +24,6 @@ MainWindow::MainWindow(QWidget *parent)
 //    connect(ui->dateAndTimeBtn, SIGNAL(released()), this, SLOT(openDateTimeDialog()));
 
 //    connect(ui->stopBtn, SIGNAL(released()), this, SLOT(stopSession()));
-//    connect(ui->powerBtn, SIGNAL(released()), this, SLOT(togglePower()));
 //    isPowerOn = false;
 //    ui->powerBtn->setText("Turn On");
 
@@ -55,10 +59,6 @@ void MainWindow::turnOffLED(QLabel *redLED) {
     redLED->setStyleSheet("border-radius: 12px; background-color: grey;");
 }
 
-void MainWindow::startNewSession() {
-    qInfo("user pressed new session");
-}
-
 void MainWindow::resumeSession() {
     qInfo("user pressed resume/start session");
 }
@@ -67,17 +67,13 @@ void MainWindow::pauseSession() {
     qInfo("user pressed pause session");
 }
 
-void MainWindow::getSessionLogs() {
-    qInfo("user pressed session logs");
-}
+//void MainWindow::openDateTimeDialog() {
+//    qInfo("user pressed date and time to set date and time");
+////    DateTimeDialog dialog(this);
+////    connect(&dialog, &DateTimeDialog::dateTimeSelected, this, &MainWindow::updateDateTime);
+////    dialog.exec();
 
-void MainWindow::openDateTimeDialog() {
-    qInfo("user pressed date and time to set date and time");
-//    DateTimeDialog dialog(this);
-//    connect(&dialog, &DateTimeDialog::dateTimeSelected, this, &MainWindow::updateDateTime);
-//    dialog.exec();
-
-}
+//}
 
 //void MainWindow::updateDateTime(const QDateTime &dateTime) {
 //    qDebug() << "New date and time selected: " << dateTime.toString();
@@ -87,7 +83,7 @@ void MainWindow::stopSession() {
 }
 
 void MainWindow::togglePower() {
-    qInfo("user pressed power button");
+    ui->stackedWidget->setVisible(isPowerOn);
 }
 
 
@@ -129,5 +125,16 @@ void MainWindow::on_backBtn_3_clicked()
 void MainWindow::on_cancelChangeBtn_clicked()
 {
     ui->stackedWidget->setCurrentIndex(0); // return home
+}
+
+
+void MainWindow::on_powerBtn_released()
+{
+    if (isPowerOn == true) {
+        isPowerOn = false;
+    } else if (isPowerOn == false) {
+        isPowerOn = true;
+    }
+    togglePower();
 }
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -5,6 +5,7 @@
 #include <QTimer>
 #include <QPushButton>
 #include <QLabel>
+#include "deviceprofile.h"
 
 QT_BEGIN_NAMESPACE
 namespace Ui { class MainWindow; }
@@ -23,15 +24,15 @@ public:
 private:
     Ui::MainWindow *ui;
     bool isPowerOn;
+    deviceProfile* devProfile;
+    int powerLevel;
+
+    void togglePower();
 
 private slots:
-    void startNewSession();
-    void getSessionLogs();
-    void openDateTimeDialog();
     void pauseSession();
     void stopSession();
     void resumeSession();
-    void togglePower();
     void toggleLED(QLabel *LED);
     void turnOnLED(QLabel *LED);
     void turnOffLED(QLabel *redLED);
@@ -43,5 +44,6 @@ private slots:
     void on_backBtn_2_clicked();
     void on_backBtn_3_clicked();
     void on_cancelChangeBtn_clicked();
+    void on_powerBtn_released();
 };
 #endif // MAINWINDOW_H

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -70,7 +70,7 @@ p, li { white-space: pre-wrap; }
      <string notr="true">background-color: rgb(135,206,250);</string>
     </property>
     <property name="currentIndex">
-     <number>1</number>
+     <number>0</number>
     </property>
     <widget class="QWidget" name="page">
      <widget class="QPushButton" name="startBtn">
@@ -162,19 +162,6 @@ p, li { white-space: pre-wrap; }
       </property>
       <property name="text">
        <string>d</string>
-      </property>
-     </widget>
-     <widget class="QPushButton" name="powerBtn">
-      <property name="geometry">
-       <rect>
-        <x>270</x>
-        <y>10</y>
-        <width>51</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>ON/OFF</string>
       </property>
      </widget>
      <widget class="QProgressBar" name="progressBar">
@@ -576,6 +563,19 @@ p, li { white-space: pre-wrap; }
       </property>
      </widget>
     </widget>
+   </widget>
+   <widget class="QPushButton" name="powerBtn">
+    <property name="geometry">
+     <rect>
+      <x>310</x>
+      <y>0</y>
+      <width>51</width>
+      <height>21</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>ON/OFF</string>
+    </property>
    </widget>
   </widget>
   <widget class="QMenuBar" name="menubar">

--- a/neureset-device-ui.pro
+++ b/neureset-device-ui.pro
@@ -10,6 +10,7 @@ CONFIG += c++11
 
 SOURCES += \
     datetimedialog.cpp \
+    deviceprofile.cpp \
     main.cpp \
     mainwindow.cpp
 
@@ -17,6 +18,7 @@ HEADERS += \
     LED.h \
     datetimedialog.h \
     deviceControl.h \
+    deviceprofile.h \
     mainwindow.h
 
 FORMS += \

--- a/neureset-device-ui.pro.user
+++ b/neureset-device-ui.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 6.0.2, 2024-04-16T00:10:51. -->
+<!-- Written by QtCreator 6.0.2, 2024-04-16T16:24:47. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>
@@ -82,6 +82,9 @@
     <valuelist type="QVariantList" key="ClangTools.SelectedFiles"/>
     <valuelist type="QVariantList" key="ClangTools.SuppressedDiagnostics"/>
     <value type="bool" key="ClangTools.UseGlobalSettings">true</value>
+   </valuemap>
+   <valuemap type="QVariantMap" key="CppEditor.QuickFix">
+    <value type="bool" key="UseGlobalSettings">true</value>
    </valuemap>
   </valuemap>
  </data>
@@ -236,9 +239,8 @@
     <valuelist type="QVariantList" key="CustomOutputParsers"/>
     <value type="int" key="PE.EnvironmentAspect.Base">2</value>
     <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">neureset-device-ui2</value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:/media/sf_elevatorSystemA3/previous_iteration/neureset-device-ui/neureset-device-ui.pro</value>
-    <value type="QString" key="ProjectExplorer.RunConfiguration.BuildKey">/media/sf_elevatorSystemA3/previous_iteration/neureset-device-ui/neureset-device-ui.pro</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:/media/sf_elevatorSystemA3/previous_iteration/3004_Final_Project/neureset-device-ui.pro</value>
+    <value type="QString" key="ProjectExplorer.RunConfiguration.BuildKey">/media/sf_elevatorSystemA3/previous_iteration/3004_Final_Project/neureset-device-ui.pro</value>
     <value type="bool" key="RunConfiguration.UseCppDebugger">false</value>
     <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
     <value type="bool" key="RunConfiguration.UseLibrarySearchPath">true</value>


### PR DESCRIPTION
Closes #24 part of the Device epic #23.

Changes: 
- Device Profile class created to hold device information (id, battery/power level) and include getters/setters for device information
- togglePower functions to make stacked UI visible and invisible depending on whether the power button is on/off

Images of on/off:
<img width="762" alt="Screenshot 2024-04-16 at 12 12 21 AM" src="https://github.com/ludigrizz/3004_Final_Project/assets/90296209/b9c7c569-ab86-4d5b-af84-4c7378970bf6">
<img width="572" alt="Screenshot 2024-04-16 at 4 24 44 PM" src="https://github.com/ludigrizz/3004_Final_Project/assets/90296209/6054836f-90a6-4c26-bb32-f47713d833fb">


* button looks a little random, because I decided I'll take the battery level, LED's and power toggle out of the stacked and leave it at the application level since they are consistent amongst views.

